### PR TITLE
Correcção da Funcionalidade de Salvar, o formulário não estava a gerar o ID ao salvar um novo cliente

### DIFF
--- a/src/app/json-server/data.json
+++ b/src/app/json-server/data.json
@@ -518,7 +518,7 @@
     },
     {
       "id": 88,
-      "name": "Bass Austin",
+      "name": "Bass Austin Moroe",
       "phone": "(244) 966-552",
       "dateOfbirth": "2020-09-09"
     },
@@ -617,6 +617,18 @@
       "name": "Adilson Barry",
       "phone": "(921) 664-281",
       "dateOfbirth": "1992-02-04"
+    },
+    {
+      "id": 105,
+      "name": "Nando bala",
+      "phone": "(244) 507-040",
+      "dateOfbirth": "1965-01-13"
+    },
+    {
+      "id": 106,
+      "name": "Aurea Lozano",
+      "phone": "(244) 507-044",
+      "dateOfbirth": "1992-03-08"
     }
   ]
 }

--- a/src/app/modules/maintenance/pages/client-form-page/client-form-page.component.html
+++ b/src/app/modules/maintenance/pages/client-form-page/client-form-page.component.html
@@ -7,12 +7,12 @@
     <form id="formClient" [formGroup]="formGroupClient" #formClient="ngForm">
       <div class="row">
         <div class="col-8 mx-auto">
-          <div class="row">
+          <!--div class="row">
             <div class="mb-3">
               <label for="id" class="form-label">ID</label>
               <input type="text" [readOnly]="true" class="form-control" id="id" name="id" formControlName="id">
             </div>
-          </div>
+          </!--div-->
           <div class="row">
             <div class="mb-3">
               <label for="name" class="form-label">Nome</label>

--- a/src/app/modules/maintenance/pages/client-form-page/client-form-page.component.ts
+++ b/src/app/modules/maintenance/pages/client-form-page/client-form-page.component.ts
@@ -18,7 +18,7 @@ export class ClientFormPageComponent {
 
   constructor(private clientService: ClientService, private formBuilder: FormBuilder, private location: Location, private activatedRoute: ActivatedRoute) {
     this.formGroupClient = this.formBuilder.group({
-      id: {disabled: true },
+      id: [''],
       name: ['', [Validators.required]],
       phone: ['', [Validators.required]],
       dateOfbirth: ['', [Validators.required]]


### PR DESCRIPTION
Foi efectuada uma correcção no serviço de salvar um novo cliente porque não estava a gerar o ID